### PR TITLE
Post message when embedded chatbot starts

### DIFF
--- a/web/app/components/base/chat/embedded-chatbot/hooks.tsx
+++ b/web/app/components/base/chat/embedded-chatbot/hooks.tsx
@@ -349,6 +349,13 @@ export const useEmbeddedChatbot = () => {
   const handleStartChat = useCallback((callback?: any) => {
     if (checkInputsRequired()) {
       setShowNewConversationItemInList(true)
+      window.parent?.postMessage(
+        {
+          type: 'dify-chatbot-form-submit',
+          payload: { inputs: newConversationInputsRef.current },
+        },
+        '*',
+      )
       callback?.()
     }
   }, [setShowNewConversationItemInList, checkInputsRequired])


### PR DESCRIPTION
## Summary
- notify parent window of chatbot form submissions by posting a `dify-chatbot-form-submit` message when chat starts

## Testing
- `pnpm lint` *(fails: GET https://registry.npmjs.org/oxlint: Forbidden - 403)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689db352f31c8323a5dc42ba77dd4106