### PR TITLE
feat(web): notify parent window with chat answers

### DIFF
--- a/web/app/components/base/chat/chat/hooks.ts
+++ b/web/app/components/base/chat/chat/hooks.ts
@@ -356,6 +356,19 @@ export const useChat = (
           if (onConversationComplete)
             onConversationComplete(conversationId.current)
 
+          window.parent?.postMessage(
+            {
+              type: 'dify-chatbot-answer',
+              payload: {
+                conversationId: conversationId.current,
+                messageId: responseItem.id,
+                question: questionItem.content,
+                answer: responseItem.content,
+              },
+            },
+            '*',
+          )
+
           if (conversationId.current && !hasStopResponded.current && onGetConversationMessages) {
             const { data }: any = await onGetConversationMessages(
               conversationId.current,


### PR DESCRIPTION
## Summary
- post `dify-chatbot-answer` message to parent window after a conversation completes so host pages can receive chat updates

## Testing
- `pnpm eslint app/components/base/chat/chat/hooks.ts && echo 'ESLint passed'`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2c5a0569c8323b3ba7e54609c2fdd